### PR TITLE
修复：ChildRecyclerView 引起的 ParentRecyclerView 加速Fling

### DIFF
--- a/app/src/main/java/com/gaohui/nestedrecyclerview/ChildRecyclerView.kt
+++ b/app/src/main/java/com/gaohui/nestedrecyclerview/ChildRecyclerView.kt
@@ -54,7 +54,7 @@ open class ChildRecyclerView @JvmOverloads constructor(context: Context, attrs: 
             if(isScrollTop() && mVelocityY != 0) {
                 //当前ChildRecyclerView已经滑动到顶部，且竖直方向加速度不为0,如果有多余的需要交由父RecyclerView继续fling
                 val flingDistance = mFlingHelper.getSplineFlingDistance(mVelocityY)
-                if(flingDistance > (Math.abs(totalDy))) {
+                if(flingDistance > (Math.abs(this@ChildRecyclerView.totalDy))) {
                     fling(0,-mFlingHelper.getVelocityByDistance(flingDistance + totalDy))
                 }
                 totalDy = 0


### PR DESCRIPTION
问题描述：

ChildRecyclerView Fling到达顶部，此时，会通过未消耗的 distance，来计算Velocity，让ParentRecyclerView继续Fling。

但这个Velocity 计算有问题。 子 ChildRecyclerView 下拉时，ParentRecyclerView 加速下滑Fling....

问题原因：

在ChildRecyclerView 计算 Velocity时，使用了ParentRecyclerView 的total

问题修复：

Kotlin 作用域问题，修正total引用